### PR TITLE
Support for DND on custom stages defined by 3rd parties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 # BlueJ files
 *.ctxt
 
+# IntelliJ files
+.idea/
+
 # Mobile Tools for Java (J2ME)
 .mtj.tmp/
 

--- a/src/main/java/com/panemu/tiwulfx/control/dock/DetachableTabPane.java
+++ b/src/main/java/com/panemu/tiwulfx/control/dock/DetachableTabPane.java
@@ -237,9 +237,9 @@ public class DetachableTabPane extends TabPane {
 
 					if (DRAG_SOURCE == null) {
 						//it means we are not dragging
-						if (getScene() != null && getScene().getWindow() instanceof TabStage) {
-							TabStage stage = (TabStage) getScene().getWindow();
-							closeStageIfNeeded(stage);
+						if (getScene() != null && getScene().getWindow() instanceof TabStageAccessor) {
+							TabStageAccessor stageAccessor = (TabStageAccessor) getScene().getWindow();
+							closeStageIfNeeded(stageAccessor.getStage());
 						}
 
 						if (getTabs().isEmpty()) {
@@ -475,9 +475,9 @@ public class DetachableTabPane extends TabPane {
 				Tab tab = DRAGGED_TAB;
 				new TabStage(tab);
 			}
-			if (DRAG_SOURCE.getScene() != null && DRAG_SOURCE.getScene().getWindow() instanceof TabStage) {
-				TabStage stage = (TabStage) DRAG_SOURCE.getScene().getWindow();
-				closeStageIfNeeded(stage);
+			if (DRAG_SOURCE.getScene() != null && DRAG_SOURCE.getScene().getWindow() instanceof TabStageAccessor) {
+				TabStageAccessor stageAccessor = (TabStageAccessor) DRAG_SOURCE.getScene().getWindow();
+				closeStageIfNeeded(stageAccessor.getStage());
 			}
 
 			if (DRAG_SOURCE.getTabs().isEmpty()) {
@@ -490,7 +490,7 @@ public class DetachableTabPane extends TabPane {
 
 	}
 
-	private void closeStageIfNeeded(TabStage stage) {
+	private void closeStageIfNeeded(Stage stage) {
 		final Set<Node> setNode = stage.getScene().getRoot().lookupAll(".tab-pane");
 		boolean empty = true;
 		for (final Node nodeTabpane : setNode) {
@@ -683,7 +683,7 @@ public class DetachableTabPane extends TabPane {
 		return DetachableTabPane.this.getScene().getWindow();
 	};
 
-	private class TabStage extends Stage {
+	private class TabStage extends Stage implements TabStageAccessor {
 
 		public TabStage(final Tab tab) {
 			final DetachableTabPane tabPane = detachableTabPaneFactory.create(
@@ -703,6 +703,11 @@ public class DetachableTabPane extends TabPane {
 			if (tab.getContent() instanceof Parent) {
 				((Parent) tab.getContent()).requestLayout();
 			}
+		}
+
+		@Override
+		public Stage getStage() {
+			return this;
 		}
 	}
 

--- a/src/main/java/com/panemu/tiwulfx/control/dock/TabStageAccessor.java
+++ b/src/main/java/com/panemu/tiwulfx/control/dock/TabStageAccessor.java
@@ -1,0 +1,16 @@
+package com.panemu.tiwulfx.control.dock;
+
+import javafx.event.EventTarget;
+import javafx.stage.Stage;
+
+/**
+ * Type providing access to a {@link Stage} that supports drag and drop operations of {@link DetachableTabPane}.
+ *
+ * @author Matt Coley
+ */
+public interface TabStageAccessor extends EventTarget {
+	/**
+	 * @return Targeted stage.
+	 */
+	Stage getStage();
+}


### PR DESCRIPTION
A 3rd party user can now define a type that implements `TabStageAccessor`. The `TabStageAccessor` will allow the `DetachableTabPane` to operate on whatever `Stage` is provided by the accessor as if it were a `TabStage`.