### PR TITLE
Allow creation of custom TabStage instances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 
 # IntelliJ files
 .idea/
+*.iml
 
 # Mobile Tools for Java (J2ME)
 .mtj.tmp/

--- a/src/main/java/com/panemu/tiwulfx/control/dock/TabStageAccessor.java
+++ b/src/main/java/com/panemu/tiwulfx/control/dock/TabStageAccessor.java
@@ -1,10 +1,12 @@
 package com.panemu.tiwulfx.control.dock;
 
 import javafx.event.EventTarget;
+import javafx.scene.control.Tab;
 import javafx.stage.Stage;
 
 /**
  * Type providing access to a {@link Stage} that supports drag and drop operations of {@link DetachableTabPane}.
+ * This allows a {@link Tab} to be dragged onto a user-defined {@link Stage} so long as it implements this type.
  *
  * @author Matt Coley
  */

--- a/src/main/java/com/panemu/tiwulfx/control/dock/TabStageFactory.java
+++ b/src/main/java/com/panemu/tiwulfx/control/dock/TabStageFactory.java
@@ -1,0 +1,25 @@
+package com.panemu.tiwulfx.control.dock;
+
+import com.panemu.tiwulfx.control.dock.DetachableTabPane.TabStage;
+import javafx.scene.control.Tab;
+import javafx.stage.Stage;
+
+/**
+ * Type providing access to creating custom {@link Stage} extending the base {@link TabStage}.
+ * This allows the user to define the type of new {@link Stage}s to create when a tab is dragged outside its
+ * containing {@link DetachableTabPane}.
+ *
+ * @author Matt Coley
+ */
+@FunctionalInterface
+public interface TabStageFactory {
+	/**
+	 * @param priorParent
+	 * 		The prior tab pane the tab belonged to.
+	 * @param tab
+	 * 		The tab being dragged into an empty space.
+	 *
+	 * @return New stage to contain the tab when the drop completes.
+	 */
+	TabStage createStage(DetachableTabPane priorParent, Tab tab);
+}


### PR DESCRIPTION
Not to be confused with my prior PR, #8 which added support for dropping `Tab` instances into user defined `Stage` types implementing `TabStageAccessor`, this is slightly different.

In my use case I needed an efficient way to get access to the **_new_** `TabStage` instances generated when a `Tab` gets dragged and dropped outside of its initial `DetachableTabPane`.  Normally this just calls `new TabStage()` which means the only option for getting the `TabStage` instance is the `stageOwnerFactory` which seemed messy since that is not the purpose of that factory.

If you have any suggestions for changes LMK.
