### PR TITLE
Allow tab pane factories to specify sub-class implementations

### DIFF
--- a/src/main/java/com/panemu/tiwulfx/control/dock/DetachableTabPane.java
+++ b/src/main/java/com/panemu/tiwulfx/control/dock/DetachableTabPane.java
@@ -306,7 +306,7 @@ public class DetachableTabPane extends TabPane {
 				pane.getChildren().remove(DetachableTabPane.this);
 				pane.getChildren().add(index, targetSplitPane);
 				targetSplitPane.getItems().add(DetachableTabPane.this);
-				DetachableTabPane dt = detachableTabPaneFactory.create(this);
+				DetachableTabPane dt = detachableTabPaneFactory.createAndInit(this);
 				dt.getTabs().add(selectedtab);
 				targetSplitPane.getItems().add(requestedIndex, dt);
 			}
@@ -316,7 +316,7 @@ public class DetachableTabPane extends TabPane {
 				targetSplitPane.setOrientation(requestedOrientation);
 			}
 			if (targetSplitPane.getOrientation() == requestedOrientation) {
-				DetachableTabPane dt = detachableTabPaneFactory.create(this);
+				DetachableTabPane dt = detachableTabPaneFactory.createAndInit(this);
 				dt.getTabs().add(selectedtab);
 				targetSplitPane.getItems().add(requestedIndex, dt);
 				int itemCount = targetSplitPane.getItems().size();
@@ -333,7 +333,7 @@ public class DetachableTabPane extends TabPane {
 				targetSplitPane.getItems().add(indexTabPane, innerSplitpane);
 				innerSplitpane.setOrientation(requestedOrientation);
 				innerSplitpane.getItems().add(DetachableTabPane.this);
-				DetachableTabPane dt = detachableTabPaneFactory.create(this);
+				DetachableTabPane dt = detachableTabPaneFactory.createAndInit(this);
 				dt.getTabs().add(selectedtab);
 				innerSplitpane.getItems().add(requestedIndex, dt);
 			}
@@ -705,7 +705,7 @@ public class DetachableTabPane extends TabPane {
 		public TabStage(final  DetachableTabPane prior, final Tab tab) {
 			// Create a new DetachableTabPane with information based on the tab pane the tab
 			// was previously associated with.
-			final DetachableTabPane tabPane = prior.detachableTabPaneFactory.create( prior);
+			final DetachableTabPane tabPane = prior.detachableTabPaneFactory.createAndInit( prior);
 			initOwner(tabPane.getStageOwnerFactory().call(this));
 			Scene scene = tabPane.getSceneFactory().call(tabPane);
 

--- a/src/main/java/com/panemu/tiwulfx/control/dock/DetachableTabPaneFactory.java
+++ b/src/main/java/com/panemu/tiwulfx/control/dock/DetachableTabPaneFactory.java
@@ -1,15 +1,30 @@
 package com.panemu.tiwulfx.control.dock;
 
 /**
- * Factory responsible to Instantiate new DetachableTabPane when a Tab is
- * detached/docked. Extend this class then implement {@link #init(DetachableTabPane)} method.
+ * Factory responsible to Instantiate new {@link DetachableTab} when a Tab is detached/docked.
+ * Extend this class then implement {@link #init(DetachableTabPane)} method to customize the newly made tab pane.
+ * <br>
+ * You can change the implementation class of {@link DetachableTabPane} used by overriding {@link #create()}.
  *
  * @author amrullah
  */
 public abstract class DetachableTabPaneFactory {
 
-	DetachableTabPane create(DetachableTabPane source) {
-		final DetachableTabPane tabPane = new DetachableTabPane();
+	/**
+	 * @return New {@link DetachableTabPane} <i>(Or any child class)</i> instance.
+	 */
+	protected DetachableTabPane create() {
+		return new DetachableTabPane();
+	}
+
+	/**
+	 * @param source
+	 * 		Tab pane to copy properties from.
+	 *
+	 * @return New {@link DetachableTabPane} with properties copied from the source tab pane.
+	 */
+	protected DetachableTabPane createAndInit(DetachableTabPane source) {
+		final DetachableTabPane tabPane = create();
 		tabPane.setSceneFactory(source.getSceneFactory());
 		tabPane.setStageOwnerFactory(source.getStageOwnerFactory());
 		tabPane.setScope(source.getScope());
@@ -22,8 +37,10 @@ public abstract class DetachableTabPaneFactory {
 	}
 
 	/**
-	 * Callback method to initialize newly created DetachableTabPane for the Tab
-	 * that is being detached/docked.
+	 * Callback method to initialize newly created {@link DetachableTabPane} for the Tab that is being detached/docked.
+	 *
+	 * @param newTabPane
+	 * 		Created tab pane to customize.
 	 */
 	protected abstract void init(DetachableTabPane newTabPane);
 }


### PR DESCRIPTION
If a user wishes to create a sub-class of `DetachableTabPane` there was previously no way to allow drag-and-drop operations to create custom types, only modify properties of a privately constructed `DetachableTabPane`.

In my case I wanted to have each `DetachableTabPane` declare a method which creates and adds a custom `Tab` implementation to the tab pane. This was part of a system for my UI to track how many tab-panes there are across multiple windows. However I encountered a problem. If I dragged a tab and created a new split or new window, then I could not control the type of `DetachableTabPane` being created. This means for my tracking system I would only ever be able to see the tabs from my initial tab pane, but anything new could not be tracked. 

This small PR modifies `DetachableTabPaneFactory` to expose a simple `return new X()` method for creating `DetachableTabPane` instances. 