### PR TITLE
Add check for isCloseIfEmpty() when removing empty tab-panes

### DIFF
--- a/src/main/java/com/panemu/tiwulfx/control/dock/DetachableTabPane.java
+++ b/src/main/java/com/panemu/tiwulfx/control/dock/DetachableTabPane.java
@@ -252,7 +252,7 @@ public class DetachableTabPane extends TabPane {
 							closeStageIfNeeded(stageAccessor.getStage());
 						}
 
-						if (getTabs().isEmpty()) {
+						if (getTabs().isEmpty() && isCloseIfEmpty()) {
 							removeFromParent(DetachableTabPane.this);
 						}
 					}

--- a/src/main/java/com/panemu/tiwulfx/control/dock/DetachableTabPane.java
+++ b/src/main/java/com/panemu/tiwulfx/control/dock/DetachableTabPane.java
@@ -577,8 +577,9 @@ public class DetachableTabPane extends TabPane {
 				siblingProvider.accept(sibling);
 				sibling.setOnClosedPassSibling(siblingProvider);
 			}
+		} else {
+			sp.getItems().remove(tabPaneToRemove);
 		}
-		sp.getItems().remove(tabPaneToRemove);
 		simplifySplitPane(sp);
 	}
 


### PR DESCRIPTION
Addresses #14 

Empty tab-panes only remove themselves from their parent when `isCloseIfEmpty()` is `true`.