### PR TITLE
Enhanced Stage Factory

### DIFF
--- a/src/main/java/com/panemu/tiwulfx/control/dock/DetachableTabPane.java
+++ b/src/main/java/com/panemu/tiwulfx/control/dock/DetachableTabPane.java
@@ -639,7 +639,7 @@ public class DetachableTabPane extends TabPane {
 	 * Set factory to generate new Stage's when Tab's are dropped outside their
 	 * current parent window. Default TabStageFactory creates {@link TabStage}.
 	 */
-	public void setStageFactory(TabStageFactory stageFactory) {
+	public void setStageFactory(TabStageFactory<?> stageFactory) {
 		this.stageFactory = stageFactory;
 	}
 
@@ -655,7 +655,7 @@ public class DetachableTabPane extends TabPane {
 	/**
 	 * Getter for {@link #setStageFactory(TabStageFactory)}
 	 */
-	public TabStageFactory getStageFactory() {
+	public TabStageFactory<?> getStageFactory() {
 		return stageFactory;
 	}
 
@@ -697,9 +697,9 @@ public class DetachableTabPane extends TabPane {
 		this.closeIfEmpty = closeIfEmpty;
 	}
 
-	private static final int STAGE_WIDTH = 400;
+	static final int STAGE_WIDTH = 400;
 
-	private TabStageFactory stageFactory = TabStage::new;
+	private TabStageFactory<?> stageFactory = TabStage::new;
 
 	private Callback<DetachableTabPane, Scene> sceneFactory = p ->
 			new Scene(p, STAGE_WIDTH, STAGE_WIDTH);

--- a/src/main/java/com/panemu/tiwulfx/control/dock/TabStageFactory.java
+++ b/src/main/java/com/panemu/tiwulfx/control/dock/TabStageFactory.java
@@ -1,25 +1,75 @@
 package com.panemu.tiwulfx.control.dock;
 
 import com.panemu.tiwulfx.control.dock.DetachableTabPane.TabStage;
+
+import javafx.scene.Parent;
+import javafx.scene.Scene;
 import javafx.scene.control.Tab;
 import javafx.stage.Stage;
 
+import java.awt.*;
+
 /**
- * Type providing access to creating custom {@link Stage} extending the base {@link TabStage}.
+ * Factory providing access to create custom {@link Stage} implementations.
  * This allows the user to define the type of new {@link Stage}s to create when a tab is dragged outside its
  * containing {@link DetachableTabPane}.
  *
+ * @param <S> The base type of stage this factory creates.
  * @author Matt Coley
  */
 @FunctionalInterface
-public interface TabStageFactory {
+public interface TabStageFactory<S extends Stage & TabStageAccessor> {
+	/**
+	 * Provides the new stage for the dropped tab to appear in.
+	 * <p>
+	 * Unlike {@link #createStage(DetachableTabPane, Tab)}, this method
+	 * doesn't modify the new stage with default configuration.
+	 *
+	 * @param priorParent
+	 * 		The prior tab pane the tab belonged to.
+	 * @param tab
+	 * 		The tab being dragged into an empty space.
+	 *
+	 * @return New stage provided to contain the tab when the drop completes.
+	 * @see #createStage(DetachableTabPane, Tab)
+	 */
+	S provide(DetachableTabPane priorParent, Tab tab);
+
 	/**
 	 * @param priorParent
 	 * 		The prior tab pane the tab belonged to.
 	 * @param tab
 	 * 		The tab being dragged into an empty space.
 	 *
-	 * @return New stage to contain the tab when the drop completes.
+	 * @return New stage created and initialized with default configuration
+	 * to contain the tab when the drop completes.
 	 */
-	TabStage createStage(DetachableTabPane priorParent, Tab tab);
+	default S createStage(DetachableTabPane priorParent, Tab tab) {
+		final S stage = provide(priorParent, tab);
+
+		// If the provided instance is a TabStage, don't apply the following
+		// as it's done within TabStage's constructor already.
+		if (!(stage instanceof TabStage)) {
+			// Create a new DetachableTabPane with information based on the tab pane the tab
+			// was previously associated with.
+			final DetachableTabPane tabPane = priorParent.getDetachableTabPaneFactory().createAndInit(priorParent);
+			stage.initOwner(tabPane.getStageOwnerFactory().call(stage));
+			final Scene scene = tabPane.getSceneFactory().call(tabPane);
+
+			scene.getStylesheets().addAll(priorParent.getScene().getStylesheets());
+			stage.setScene(scene);
+
+			final Point p = MouseInfo.getPointerInfo().getLocation();
+			stage.setX( p.x - (DetachableTabPane.STAGE_WIDTH >> 1) );
+			stage.setY( p.y );
+			stage.show();
+			tabPane.getTabs().add(tab);
+			tabPane.getSelectionModel().select(tab);
+			if (tab.getContent() instanceof Parent) {
+				((Parent) tab.getContent()).requestLayout();
+			}
+		}
+
+		return stage;
+	}
 }


### PR DESCRIPTION
Amazing project by the way.

I was using these changes just for personal use, but I thought why not share it, so here it is, and feel free to let me know your thoughts.

Currently, the `TabStageFactory` API has some limitations.
This PR enhances usability with minimal changes.
Here’s an overview of the additions:

1. **Independent Custom Stages**: 
   Now accepts custom Stage implementations that is not a TabStage instance.
   (e.g., stages from other libraries).
2. **Overridable Default Configuration**:
   The default stage configuration can now be overridden in the factory if necessary.

___

**Changes are the following:**

TabStageFactory now has two methods: provide and createStage.

1. **[provide](src/main/java/com/panemu/tiwulfx/control/dock/TabStageFactory.java)**:
   A lambda function which supplies the Stage.
2. **[createStage](src/main/java/com/panemu/tiwulfx/control/dock/TabStageFactory.java)**:
   This method creates the stage with default configuration similar to that of TabStage's constructor.
   The default configuration can be overridden. (Technically, `TabStage` wouldn't need any logic in its constructor anymore)

**API example:**
```
TabStageFactory<LinuxStage> factory = (prior, tab) -> new LinuxStage(); // LinuxStage does *not* extend TagStage
Stage a = factory.provide(prior, tab); // Calls the lambda to supply the stage
Stage b = factory.createStage(prior, tab); // Creates a stage with default configuration; internally calls `provide`
detachableTabPane.setStageFactory(factory);
```

I’ve kept backward compatibility in mind, but there is a single breaking change:
- Code that previously called `createStage` expecting a `TabStage` instance will now result in a compilation error. 
  The factory is no longer restricted exclusively to `TabStage` instances.

```
TabStage a = createStage(priorParent, tab); // Error, as the return type is now at least `Stage & TabStageAccessor`.
TabStage b = (TabStage) createStage(priorParent, tab); // OK
Stage c = createStage(priorParent, tab); // OK
TabStageAccessor d = createStage(priorParent, tab); // OK
```