### PR TITLE
Set `tabHeight` to be dynamic

### DIFF
--- a/src/main/java/com/panemu/tiwulfx/control/dock/DetachableTabPane.java
+++ b/src/main/java/com/panemu/tiwulfx/control/dock/DetachableTabPane.java
@@ -432,6 +432,8 @@ public class DetachableTabPane extends TabPane {
 		} else {
 			pos = null;
 			double tabpos = -1;
+			double tabAreaPos = getTabHeaderArea().getLayoutBounds().getMaxY();
+
 			for (int i = 1; i < lstTabPoint.size(); i++) {
 				if (event.getX() < lstTabPoint.get(i)) {
 					tabpos = lstTabPoint.get(i - 1);
@@ -446,7 +448,7 @@ public class DetachableTabPane extends TabPane {
 					tabpos = lstTabPoint.get(index);
 				}
 			}
-			dropHint.refresh(tabpos, DetachableTabPane.this.getWidth(), DetachableTabPane.this.getHeight());
+			dropHint.refreshInsertion(tabpos, tabAreaPos, DetachableTabPane.this.getWidth(), DetachableTabPane.this.getHeight());
 		}
 	}
 

--- a/src/main/java/com/panemu/tiwulfx/control/dock/TabDropHint.java
+++ b/src/main/java/com/panemu/tiwulfx/control/dock/TabDropHint.java
@@ -11,6 +11,7 @@ import javafx.scene.shape.*;
 public class TabDropHint {
 
 	private double tabPos;
+	private double tabAreaPos;
 	private double width;
 	private double height;
 	private double startX;
@@ -38,11 +39,12 @@ public class TabDropHint {
 		}
 	}
 	
-	void refresh(double tabPos, double width, double height) {
+	void refreshInsertion(double tabPos, double tabAreaPos, double width, double height) {
 		boolean regenerate  = this.tabPos != tabPos
 				  || this.width != width
 				  || this.height != height;
 		this.tabPos = tabPos;
+		this.tabAreaPos = tabAreaPos;
 		this.width = width;
 		this.height = height;
 		startX = 0;
@@ -51,7 +53,18 @@ public class TabDropHint {
 			generateInsertionPath(path, tabPos, width - 2, height - 2);
 		}
 	}
-	
+
+	/**
+	 * Returns the maximum Y-coordinate of the tab area.
+	 * <p>
+	 * The tab area refers to the node containing all the tabs.
+	 *
+	 * @return The maximum Y-coordinate of the tab area.
+	 */
+	protected double getTabAreaPos() {
+		return tabAreaPos;
+	}
+
 	protected void generateAdjacentPath(Path path, double startX, double startY, double width, double height) {
 		path.getElements().clear();
 		MoveTo moveTo = new MoveTo();
@@ -65,7 +78,7 @@ public class TabDropHint {
 	}
 
 	protected void generateInsertionPath(Path path, double tabPos, double width, double height) {
-		int tabHeight = 28;
+		double tabHeight = getTabAreaPos();
 		int start = 2;
 		tabPos = Math.max(start, tabPos);
 		path.getElements().clear();

--- a/src/test/java/com/panemu/tiwulfx/control/dock/demo1/CustomDropHint.java
+++ b/src/test/java/com/panemu/tiwulfx/control/dock/demo1/CustomDropHint.java
@@ -33,7 +33,7 @@ public class CustomDropHint extends TabDropHint {
 
 	@Override
 	protected void generateInsertionPath(Path path, double tabPos, double width, double height) {
-		int tabHeight = 28;
+		double tabHeight = getTabAreaPos();
 		int start = 2;
 		dropGuide.getChildren().clear();
 		dropGuide.setLayoutX(start);


### PR DESCRIPTION
**[TabDropHint](https://github.com/panemu/tiwulfx-dock/blob/main/src/main/java/com/panemu/tiwulfx/control/dock/TabDropHint.java)** currently uses a hardcoded `tabHeight` value of `28`. 
This PR updates the implementation to make `tabHeight` dynamic, while maintaining backward compatibility.
The new behavior becomes more flexible and responsive to changes in the UI.
Feel free to let me know your thoughts.

### (New) Dynamic Tab Height:
![Dynamic tab height](https://github.com/user-attachments/assets/fb95de69-bfdd-4d65-8776-d5b5ca1670d0)

### (Old) Hardcoded Tab Height:
![Hard-coded tab height](https://github.com/user-attachments/assets/fb44d872-39bd-48db-9d79-07b1649a62aa)

___

**Changes are the following**:

1. The signature of the internal mothod `refresh(tabPos, width, height)` has been updated to `refreshInsertion(tabPos, tabAreaPos, width, height)`. The name change is to avoid conflict with `refresh(startX, startY, width, height)`, as both methods accept the same primitive types (double).
2. A new protected method `getTabAreaPos` has been added within `TabDropHint`, returning the maximum Y-coordinate of the tab area.
3. The `CustomDropHint` sample class now uses dynamic height instead of a fixed height.